### PR TITLE
Option to provide unit of measurement when running `today`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 build/
 .env
+coverage/

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -17,7 +17,7 @@ export default {
   clearMocks: true,
 
   // Indicates whether the coverage information should be collected while executing the test
-  // collectCoverage: false,
+  collectCoverage: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
   // collectCoverageFrom: undefined,

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -41,9 +41,23 @@ async function promptConfigurationQuestions() {
       validate: (value) =>
         LANGUAGES.includes(value) ? true : 'Language code not found',
     },
+    {
+      type: 'select',
+      name: 'unit',
+      message: 'Pick a unit of measurement',
+      choices: [
+        {
+          title: 'Celsius',
+          value: 'metric',
+        },
+        { title: 'Kelvin', value: 'standard' },
+        { title: 'Fahrenheit', value: 'imperial' },
+      ],
+      initial: 1,
+    },
   ]
 
-  const { city, state, country, language } = await prompts(questions)
+  const { city, state, country, language, unit } = await prompts(questions)
 
   const location = await getGeocoding(city, state, country)
 
@@ -90,6 +104,7 @@ async function promptConfigurationQuestions() {
     lat: isLocationCorrect ? location.lat : lat,
     lon: isLocationCorrect ? location.lon : lon,
     language,
+    unit,
   }
 }
 
@@ -100,6 +115,7 @@ async function validateSettings({
   lat,
   lon,
   language,
+  unit,
 }: Awaited<ReturnType<typeof promptConfigurationQuestions>>) {
   let userSettings: UserSettings
 
@@ -113,6 +129,7 @@ async function validateSettings({
         lon,
       },
       language,
+      unit,
     })
   } catch (err) {
     console.error(err)

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -6,7 +6,8 @@ const menus = {
 
     today .............. show weather for today
     version ............ show package version
-    help ............... show help menu for a command`,
+    help ............... show help menu for a command
+    config ............. configure your settings (location, language & more)`,
 
   today: `
     outside today <options>

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -12,7 +12,8 @@ const menus = {
   today: `
     outside today <options>
 
-    --location ..... the location to use -> format: city,state code,country`,
+    --location=<location> ..... the <location> to use -> format: city,state code,country
+    --unit=<unit> ......... use <unit> as unit of measurement. -> choose between "metric" for celsius, "standard" for kelvin and "imperial for fahrenheit. default is metric`,
 
   forecast: `
     outside forecast <options>

--- a/src/commands/today.test.ts
+++ b/src/commands/today.test.ts
@@ -1,3 +1,4 @@
+import { UNITS, Unit } from '../locale/units'
 import * as GetGeocoding from '../utils/geocoding'
 import * as GetLocation from '../utils/location'
 import * as UserConfig from '../utils/user-settings'
@@ -82,5 +83,83 @@ describe('Today Command', () => {
     })
 
     expect(getLocationByIpSpy).toHaveBeenCalled()
+  })
+
+  it.each(UNITS)(
+    'fetch todays weather using ____ as unit',
+    async (unit: Unit) => {
+      const userSettings = {
+        location: {
+          city: 'Rio de Janeiro',
+          state: 'RJ',
+          country: 'BR',
+          lat: 30,
+          lon: 30,
+        },
+        language: 'pt_br',
+      } satisfies UserConfig.UserSettings
+
+      jest
+        .spyOn(UserConfig, 'readUserSettings')
+        .mockResolvedValueOnce(userSettings)
+
+      const getWeatherSpy = jest
+        .spyOn(GetWeather, 'default')
+        .mockResolvedValueOnce({
+          humidity: 90,
+          feels_like: 30,
+          temp: 20,
+          temp_max: 30,
+          temp_min: 10,
+        })
+
+      await today({
+        _: [],
+        unit: unit,
+      })
+
+      expect(getWeatherSpy).toHaveBeenCalledWith({
+        lat: userSettings.location.lat,
+        lon: userSettings.location.lon,
+        unit: unit,
+      })
+    }
+  )
+
+  it('should use default unit if unit argument is not provided', async () => {
+    const userSettings = {
+      location: {
+        city: 'Rio de Janeiro',
+        state: 'RJ',
+        country: 'BR',
+        lat: 30,
+        lon: 30,
+      },
+      language: 'pt_br',
+    } satisfies UserConfig.UserSettings
+
+    jest
+      .spyOn(UserConfig, 'readUserSettings')
+      .mockResolvedValueOnce(userSettings)
+
+    const getWeatherSpy = jest
+      .spyOn(GetWeather, 'default')
+      .mockResolvedValueOnce({
+        humidity: 90,
+        feels_like: 30,
+        temp: 20,
+        temp_max: 30,
+        temp_min: 10,
+      })
+
+    await today({
+      _: [],
+    })
+
+    expect(getWeatherSpy).toHaveBeenCalledWith({
+      lat: userSettings.location.lat,
+      lon: userSettings.location.lon,
+      unit: 'metric',
+    })
   })
 })

--- a/src/commands/today.ts
+++ b/src/commands/today.ts
@@ -1,5 +1,6 @@
 import { ParsedArgs } from 'minimist'
 import { z } from 'zod'
+import { UNITS_SYMBOLS, Unit } from '../locale/units'
 import error from '../utils/error'
 import getGeocoding from '../utils/geocoding'
 import getLocationByIp from '../utils/location'
@@ -8,19 +9,24 @@ import getWeather from '../utils/weather'
 
 const todayArgSchema = z.object({
   location: z.string().optional(),
-  units: z
-    .enum(['metric', 'standard', 'imperial'])
-    .optional()
-    .default('metric'),
+  unit: z.enum(['metric', 'standard', 'imperial']).optional().default('metric'),
 })
 
 export type TodayArguments = ParsedArgs & z.infer<typeof todayArgSchema>
 
-function printWeather(weather: Awaited<ReturnType<typeof getWeather>>) {
+function printWeather(
+  weather: Awaited<ReturnType<typeof getWeather>>,
+  unit: Unit
+) {
+  const degree = UNITS_SYMBOLS[unit]
+
   console.log(
-    `Temperature (celsius):: min is ${weather.temp_min} - max is ${weather.temp_max} - current: ${weather.temp} - feels like ${weather.feels_like}`
+    `Now is: ${weather.temp + degree} but feels like ${
+      weather.feels_like + degree
+    }\nYou should expect a min of ${weather.temp_min + degree} and a max of ${
+      weather.temp_max + degree
+    } for today.\nThe humidity is ${weather.humidity}%`
   )
-  console.log(`The humidity is ${weather.humidity}%`)
 }
 
 function printLocation(location: Awaited<ReturnType<typeof getLocationByIp>>) {
@@ -29,69 +35,83 @@ function printLocation(location: Awaited<ReturnType<typeof getLocationByIp>>) {
   )
 }
 
-function parseTodayArguments(args: TodayArguments) {
-  try {
-    const parsedArgs = todayArgSchema.parse(args)
-    const [city, state, country] = args.location.split(',')
+function parseTodayArguments(_args: TodayArguments) {
+  let parsedArgs: z.infer<typeof todayArgSchema>
 
-    return {
-      location: {
-        city: city.trim(),
-        state: state.trim(),
-        country: country.trim(),
-      },
-      units: parsedArgs.units,
-    }
+  try {
+    parsedArgs = todayArgSchema.parse(_args)
   } catch (err) {
+    // todo: format error (improve message)
     error(err.message, true)
+  }
+
+  let location: { city: string; state: string; country: string }
+
+  if (parsedArgs.location) {
+    const [city, state, country] = parsedArgs.location.split(',')
+    location = {
+      city: city.trim(),
+      state: state.trim(),
+      country: country.trim(),
+    }
+  }
+
+  return {
+    location,
+    unit: parsedArgs.unit,
   }
 }
 
 export default async (args: TodayArguments) => {
   const features = parseTodayArguments(args)
 
-  let userSettings: UserSettings = {
+  let userSettings: UserSettings = (await readUserSettings()) || {
     location: {},
-    language: undefined,
+    unit: features.unit,
   }
 
+  if (features.location) {
+    const geocoding = await getGeocoding(
+      features.location.city,
+      features.location.state,
+      features.location.country
+    )
+
+    userSettings.location.lat = geocoding.lat
+    userSettings.location.lon = geocoding.lon
+  }
+
+  const hasCoordinates =
+    userSettings.location?.lat !== undefined &&
+    userSettings.location?.lon !== undefined
+
   try {
-    if (features.location) {
-      const geocoding = await getGeocoding(
-        features.location.city,
-        features.location.state,
-        features.location.country
-      )
-
-      userSettings.location.lat = geocoding.lat
-      userSettings.location.lon = geocoding.lon
-    } else {
-      const cachedSettings = await readUserSettings()
-
-      if (cachedSettings) {
-        userSettings = cachedSettings
-        console.log('Using your configuration.')
-      }
-    }
-
-    const hasGeoPosition =
-      userSettings.location.lat && userSettings.location.lon
-
-    if (!hasGeoPosition) {
+    if (!hasCoordinates) {
       const location = await getLocationByIp()
       userSettings.location.lat = location.latitude
       userSettings.location.lon = location.longitude
-
       printLocation(location)
     }
+  } catch (err) {
+    error('We were not able to get your location based on your IP.', true)
+  }
 
+  const unitToUse = args.unit
+    ? features.unit
+    : (userSettings.unit as Unit) || features.unit
+
+  try {
     const weather = await getWeather({
       lat: userSettings.location.lat,
       lon: userSettings.location.lon,
+      unit: unitToUse,
     })
 
-    printWeather(weather)
+    printWeather(weather, unitToUse)
   } catch (err) {
-    console.error(err)
+    error(
+      "Our weather server did not respond well. We're sorry! Try again later.",
+      true
+    )
   }
 }

--- a/src/locale/units.ts
+++ b/src/locale/units.ts
@@ -1,0 +1,13 @@
+export type Unit = 'metric' | 'standard' | 'imperial'
+
+export type UnitsSymbol = {
+  [key in Unit]: string
+}
+
+export const UNITS = ['metric', 'standard', 'imperial']
+
+export const UNITS_SYMBOLS: UnitsSymbol = {
+  metric: '°C',
+  imperial: '°F',
+  standard: '°K',
+}

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,5 +1,7 @@
+const isTestEnvironment = process.env.NODE_ENV === 'test'
+
 export default function error(message: string, exit: boolean) {
   console.error(message)
 
-  exit && process.exit(1)
+  exit && !isTestEnvironment && process.exit(1)
 }

--- a/src/utils/geocoding.ts
+++ b/src/utils/geocoding.ts
@@ -19,8 +19,6 @@ export default async function getGeocoding(
   state: string,
   country: string
 ) {
-  console.log(`Fetching geocoding [${city}, ${state}, ${country}]`)
-
   const q = `${city},${state},${country}`
 
   const { data } = await axios.get<GeocingResponse>(

--- a/src/utils/user-settings.ts
+++ b/src/utils/user-settings.ts
@@ -15,6 +15,7 @@ export const UserSettigsSchema = z
       })
       .required(),
     language: z.string().optional(),
+    unit: z.string().optional(),
   })
   .required()
 
@@ -41,8 +42,12 @@ export async function readUserSettings(): Promise<UserSettings | null> {
   try {
     data = await readFile(userSettingsFilePath, 'utf-8')
   } catch (err) {
-    console.error('Error reading from user settings file')
-    return null
+    if (err.code === 'ENOENT') {
+      return null
+    } else {
+      console.error('Error reading from user settings file', err)
+      throw err
+    }
   }
 
   try {

--- a/src/utils/weather.ts
+++ b/src/utils/weather.ts
@@ -18,9 +18,24 @@ const WeatherSchema = z
 
 type WeatherResponse = z.infer<typeof WeatherSchema>
 
-export default async function getWeather(lat: number, lon: number) {
+const WeatherOptions = z
+  .object({
+    lat: z.number(),
+    lon: z.number(),
+    unit: z
+      .enum(['metric', 'imperial', 'standard'])
+      .optional()
+      .default('metric'),
+  })
+  .required()
+
+export default async function getWeather({
+  lat,
+  lon,
+  unit,
+}: z.infer<typeof WeatherOptions>) {
   const { data } = await axios.get<WeatherResponse>(
-    `https://api.openweathermap.org/data/2.5/weather?lat=${lat}&lon=${lon}&units=metric&appid=${env.OPEN_WEATHER_API_KEY}`
+    `https://api.openweathermap.org/data/2.5/weather?lat=${lat}&lon=${lon}&units=${unit}&appid=${env.OPEN_WEATHER_API_KEY}`
   )
 
   return {


### PR DESCRIPTION
Now, it is possible to provide a unit of measurement when running `$ outside today` and also when running `$ outside config`

To use it, just use  the flag `--unit=<unit>`, where `unit` can be:
- metric (celsius)
- standard (kelvin)
- imperial (Fahrenheit)

and there's not need to convert one value to another, OpenWeather API does all the word 🌟 

